### PR TITLE
fix(frontend): Fix ReferenceError: fileInputRef is not defined

### DIFF
--- a/frontend/src/BulkEditTable.tsx
+++ b/frontend/src/BulkEditTable.tsx
@@ -82,6 +82,20 @@ const BulkEditTable: React.FC = () => {
   const csvDropdownRef = useRef<HTMLDivElement>(null);
   const rowDropdownRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      // This is a placeholder for the actual import logic
+      // In a real implementation, you would parse the CSV and update the table data
+      console.log('Selected file:', file.name);
+      // Reset the file input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
 
   // --- Unsaved Changes Warning ---
   const hasUnsavedChanges = Object.keys(editedRows).length > 0;


### PR DESCRIPTION
The `fileInputRef` was being used in `BulkEditTable.tsx` but was not defined. This was because the component was an older version that was missing the ref definition and the `handleFileChange` function.

This commit adds the missing `fileInputRef` and a placeholder `handleFileChange` function to resolve the runtime error.