### PR TITLE
This commit introduces a new feature to link tasks associated with a …

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 import models
 from database import engine
-from routers import plants, garden_plans, plantings, tasks, users
+from routers import plants, garden_plans, plantings, tasks, users, task_groups
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -22,3 +22,4 @@ app.include_router(garden_plans.router)
 app.include_router(plantings.router)
 app.include_router(tasks.router)
 app.include_router(users.router)
+app.include_router(task_groups.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -174,11 +174,17 @@ class TaskStatus(str, enum.Enum):
     IN_PROGRESS = "In Progress"
     COMPLETED = "Completed"
 
+class TaskGroup(Base):
+    __tablename__ = "task_groups"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    tasks: Mapped[List["Task"]] = relationship(back_populates="task_group")
+
 class Task(Base):
     __tablename__ = "tasks"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     garden_plan_id: Mapped[int] = mapped_column(ForeignKey("garden_plans.id"))
     planting_id: Mapped[Optional[int]] = mapped_column(ForeignKey("plantings.id"), nullable=True)
+    task_group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("task_groups.id"), nullable=True)
     name: Mapped[str] = mapped_column(String)
     description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     due_date: Mapped[Optional[datetime]] = mapped_column(Date, nullable=True)
@@ -186,3 +192,4 @@ class Task(Base):
 
     garden_plan: Mapped["GardenPlan"] = relationship(back_populates="tasks")
     planting: Mapped[Optional["Planting"]] = relationship(back_populates="tasks")
+    task_group: Mapped[Optional["TaskGroup"]] = relationship(back_populates="tasks")

--- a/backend/routers/task_groups.py
+++ b/backend/routers/task_groups.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from typing import List
+
+import schemas
+import crud
+from database import SessionLocal
+
+router = APIRouter()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+class TaskGroupUpdatePayload(BaseModel):
+    date_diff_days: int
+
+@router.put("/api/task-groups/{group_id}", response_model=List[schemas.Task])
+def update_task_group_endpoint(group_id: int, payload: TaskGroupUpdatePayload, db: Session = Depends(get_db)):
+    updated_tasks = crud.update_tasks_in_group(db, group_id=group_id, date_diff_days=payload.date_diff_days)
+    if not updated_tasks:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task group not found or no tasks in group")
+    return updated_tasks
+
+@router.put("/api/task-groups/{group_id}/unlink", response_model=List[schemas.Task])
+def unlink_task_group_endpoint(group_id: int, db: Session = Depends(get_db)):
+    updated_tasks = crud.unlink_tasks_in_group(db, group_id=group_id)
+    if not updated_tasks:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task group not found or no tasks in group")
+    return updated_tasks

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -101,6 +101,18 @@ class Plant(PlantBase):
     id: int
     model_config = ConfigDict(from_attributes=True)
 
+# --- Task Group Schemas ---
+class TaskGroupBase(BaseModel):
+    pass
+
+class TaskGroupCreate(TaskGroupBase):
+    pass
+
+class TaskGroup(TaskGroupBase):
+    id: int
+    tasks: List["Task"] = []
+    model_config = ConfigDict(from_attributes=True)
+
 # --- Task Schemas ---
 class TaskBase(BaseModel):
     name: str
@@ -111,17 +123,22 @@ class TaskBase(BaseModel):
 class TaskCreate(TaskBase):
     garden_plan_id: int
     planting_id: Optional[int] = None
+    task_group_id: Optional[int] = None
+
 
 class TaskUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     due_date: Optional[date] = None
     status: Optional[TaskStatus] = None
+    task_group_id: Optional[int] = None
+
 
 class Task(TaskBase):
     id: int
     garden_plan_id: int
     planting_id: Optional[int] = None
+    task_group_id: Optional[int] = None
     model_config = ConfigDict(from_attributes=True)
 
 # --- Planting Schemas ---

--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -42,130 +42,6 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
       return match ? parseInt(match[0], 10) : null;
   };
 
-  const addDays = (dateStr: string, days: number): string => {
-    if (!dateStr) return '';
-    const date = new Date(dateStr + 'T00:00:00Z');
-    date.setDate(date.getDate() + days);
-    return format(date, 'yyyy-MM-dd');
-  };
-
-  const subtractDays = (dateStr: string, days: number): string => {
-    if (!dateStr) return '';
-    const date = new Date(dateStr + 'T00:00:00Z');
-    date.setDate(date.getDate() - days);
-    return format(date, 'yyyy-MM-dd');
-  };
-
-  const handleSowDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newSowDate = e.target.value;
-    setValue("sowDate", newSowDate, { shouldValidate: true });
-
-    const daysToMaturity = parseDays(watch("timeToMaturity"));
-    if (!daysToMaturity || !newSowDate) return;
-
-    if (watch("plantingMethod") === PlantingMethod.DIRECT_SEEDING) {
-      setValue('harvestDate', addDays(newSowDate, daysToMaturity));
-    } else if (watch("plantingMethod") === PlantingMethod.SEED_STARTING) {
-      const daysToTransplant = parseDays(watch("daysToTransplant"));
-      if (daysToTransplant) {
-        const calculatedTransplantDate = addDays(newSowDate, daysToTransplant);
-        setValue('transplantDate', calculatedTransplantDate);
-        setValue('harvestDate', addDays(calculatedTransplantDate, daysToMaturity));
-      }
-    }
-  };
-
-  const handleTransplantDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTransplantDate = e.target.value;
-    setValue("transplantDate", newTransplantDate, { shouldValidate: true });
-
-    const daysToMaturity = parseDays(watch("timeToMaturity"));
-    if (!daysToMaturity || !newTransplantDate) return;
-
-    if (watch("plantingMethod") === PlantingMethod.SEEDLING) {
-      setValue('harvestDate', addDays(newTransplantDate, daysToMaturity));
-    }
-  };
-
-  const handleHarvestDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newHarvestDate = e.target.value;
-    setValue("harvestDate", newHarvestDate, { shouldValidate: true });
-
-    const daysToMaturity = parseDays(watch("timeToMaturity"));
-    if (!daysToMaturity || !newHarvestDate) return;
-
-    const baseDate = subtractDays(newHarvestDate, daysToMaturity);
-
-    if (watch("plantingMethod") === PlantingMethod.DIRECT_SEEDING) {
-      setValue('sowDate', baseDate);
-      setValue('transplantDate', '');
-    } else if (watch("plantingMethod") === PlantingMethod.SEEDLING) {
-      setValue('transplantDate', baseDate);
-      setValue('sowDate', '');
-    } else if (watch("plantingMethod") === PlantingMethod.SEED_STARTING) {
-      const daysToTransplant = parseDays(watch("daysToTransplant"));
-      if (daysToTransplant) {
-        setValue('transplantDate', baseDate);
-        setValue('sowDate', subtractDays(baseDate, daysToTransplant));
-      }
-    }
-  };
-
-  const handleDaysToTransplantChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newDays = e.target.value;
-    setValue("daysToTransplant", newDays, { shouldValidate: true });
-
-    const sowDate = watch("sowDate");
-    if (watch("plantingMethod") === PlantingMethod.SEED_STARTING && sowDate) {
-        const daysToMaturity = parseDays(watch("timeToMaturity"));
-        const daysToTransplant = parseDays(newDays);
-
-        if (daysToTransplant) {
-            const calculatedTransplantDate = addDays(sowDate, daysToTransplant);
-            setValue('transplantDate', calculatedTransplantDate);
-            if (daysToMaturity) {
-                setValue('harvestDate', addDays(calculatedTransplantDate, daysToMaturity));
-            }
-        }
-    }
-  };
-
-  const handlePlantingMethodChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newMethod = e.target.value as PlantingMethod;
-    setValue("plantingMethod", newMethod, { shouldValidate: true });
-
-    const sowDate = watch("sowDate");
-    const harvestDate = watch("harvestDate");
-    const daysToMaturity = parseDays(watch("timeToMaturity"));
-    const daysToTransplant = parseDays(watch("daysToTransplant"));
-
-    if (newMethod === PlantingMethod.DIRECT_SEEDING) {
-        setValue("transplantDate", "");
-    } else if (newMethod === PlantingMethod.SEEDLING) {
-        setValue("sowDate", "");
-    }
-
-    if (daysToMaturity && sowDate) {
-        if (newMethod === PlantingMethod.DIRECT_SEEDING) {
-            setValue('harvestDate', addDays(sowDate, daysToMaturity));
-        } else if (newMethod === PlantingMethod.SEED_STARTING && daysToTransplant) {
-            const calculatedTransplantDate = addDays(sowDate, daysToTransplant);
-            setValue('transplantDate', calculatedTransplantDate);
-            setValue('harvestDate', addDays(calculatedTransplantDate, daysToMaturity));
-        }
-    } else if (daysToMaturity && harvestDate) {
-        const baseDate = subtractDays(harvestDate, daysToMaturity);
-        if (newMethod === PlantingMethod.DIRECT_SEEDING) {
-            setValue('sowDate', baseDate);
-        } else if (newMethod === PlantingMethod.SEEDLING) {
-            setValue('transplantDate', baseDate);
-        } else if (newMethod === PlantingMethod.SEED_STARTING && daysToTransplant) {
-            setValue('transplantDate', baseDate);
-            setValue('sowDate', subtractDays(baseDate, daysToTransplant));
-        }
-    }
-  };
-
   useEffect(() => {
     if (isOpen && plant) {
       let defaultPlantingMethod = PlantingMethod.SEED_STARTING;
@@ -191,35 +67,6 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
             defaults.transplantDate = dateStr;
         } else {
             defaults.sowDate = dateStr;
-        }
-      }
-
-      const daysToMaturity = parseDays(defaults.timeToMaturity);
-      const daysToTransplant = parseDays(defaults.daysToTransplant);
-
-      if (daysToMaturity) {
-        if (defaults.sowDate) {
-          if (defaults.plantingMethod === PlantingMethod.DIRECT_SEEDING) {
-            defaults.harvestDate = addDays(defaults.sowDate, daysToMaturity);
-          } else if (defaults.plantingMethod === PlantingMethod.SEED_STARTING && daysToTransplant) {
-            const calculatedTransplantDate = addDays(defaults.sowDate, daysToTransplant);
-            defaults.transplantDate = calculatedTransplantDate;
-            defaults.harvestDate = addDays(calculatedTransplantDate, daysToMaturity);
-          }
-        } else if (defaults.transplantDate) {
-           if (defaults.plantingMethod === PlantingMethod.SEEDLING) {
-             defaults.harvestDate = addDays(defaults.transplantDate, daysToMaturity);
-           }
-        } else if (defaults.harvestDate) {
-            const baseDate = subtractDays(defaults.harvestDate, daysToMaturity);
-            if (defaults.plantingMethod === PlantingMethod.DIRECT_SEEDING) {
-              defaults.sowDate = baseDate;
-            } else if (defaults.plantingMethod === PlantingMethod.SEEDLING) {
-              defaults.transplantDate = baseDate;
-            } else if (defaults.plantingMethod === PlantingMethod.SEED_STARTING && daysToTransplant) {
-              defaults.transplantDate = baseDate;
-              defaults.sowDate = subtractDays(baseDate, daysToTransplant);
-            }
         }
       }
 
@@ -261,7 +108,6 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
           <div className="mb-4">
             <label className="block text-sm font-medium text-gray-700">Planting Method</label>
             <select {...register("plantingMethod")}
-              onChange={handlePlantingMethodChange}
               className="mt-1 block w-full p-2 border border-gray-300 rounded-md">
               {Object.values(PlantingMethod).map(method => (
                 <option key={method} value={method}>{method}</option>
@@ -292,7 +138,6 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
                     type="number" 
                     id="days-to-transplant" 
                     {...register("daysToTransplant")}
-                    onChange={handleDaysToTransplantChange}
                     className="mt-1 block w-full p-2 border border-gray-300 rounded-md"
                 />
              </div>
@@ -301,28 +146,21 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
           {(watch("plantingMethod") === PlantingMethod.SEED_STARTING || watch("plantingMethod") === PlantingMethod.DIRECT_SEEDING) && (
              <div className="mb-4">
                 <label htmlFor="sow-date" className="block text-sm font-medium text-gray-700">Sow Date</label>
-                <input type="date" id="sow-date" {...register("sowDate")} onChange={handleSowDateChange} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
+                <input type="date" id="sow-date" {...register("sowDate")} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
              </div>
           )}
 
-          {watch("plantingMethod") === PlantingMethod.SEEDLING && (
+          {(watch("plantingMethod") === PlantingMethod.SEED_STARTING || watch("plantingMethod") === PlantingMethod.SEEDLING) && (
             <div className="mb-4">
                 <label htmlFor="transplant-date" className="block text-sm font-medium text-gray-700">Transplant Date</label>
-                <input type="date" id="transplant-date" {...register("transplantDate")} onChange={handleTransplantDateChange} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
-            </div>
-          )}
-          
-          {watch("plantingMethod") === PlantingMethod.SEED_STARTING && (
-            <div className="mb-4">
-                <label htmlFor="transplant-date-calculated" className="block text-sm font-medium text-gray-700">Calculated Transplant Date</label>
-                <input type="date" id="transplant-date-calculated" {...register("transplantDate")} readOnly className="mt-1 block w-full p-2 border border-gray-200 rounded-md bg-gray-100"/>
+                <input type="date" id="transplant-date" {...register("transplantDate")} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
             </div>
           )}
 
           <div className="mb-4">
             <label htmlFor="harvest-date" className="block text-sm font-medium text-gray-700">Target Harvest Date</label>
-            <input type="date" id="harvest-date" {...register("harvestDate")} onChange={handleHarvestDateChange} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
-            <p className="text-xs text-gray-500 mt-1">Change this to automatically calculate the planting dates.</p>
+            <input type="date" id="harvest-date" {...register("harvestDate")} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
+            <p className="text-xs text-gray-500 mt-1">Enter any known dates. The related tasks will be created automatically.</p>
           </div>
 
           <div className="flex justify-end space-x-2 mt-6">

--- a/frontend/src/store/plantApi.ts
+++ b/frontend/src/store/plantApi.ts
@@ -221,6 +221,23 @@ export const plantApi = createApi({
         invalidatesTags: (result, error, id) => [{ type: 'Task', id }, { type: 'Task', id: 'LIST' }, { type: 'GardenPlan', id: 'LIST' }],
     }),
 
+    updateTaskGroup: builder.mutation<Task[], { groupId: number, dateDiffDays: number }>({
+      query: ({ groupId, dateDiffDays }) => ({
+        url: `task-groups/${groupId}`,
+        method: 'PUT',
+        body: { date_diff_days: dateDiffDays },
+      }),
+      invalidatesTags: (result, error, { groupId }) => [{ type: 'Task', id: 'LIST' }, { type: 'GardenPlan', id: 'LIST' }],
+    }),
+
+    unlinkTaskGroup: builder.mutation<Task[], { groupId: number }>({
+      query: ({ groupId }) => ({
+        url: `task-groups/${groupId}/unlink`,
+        method: 'PUT',
+      }),
+      invalidatesTags: (result, error, { groupId }) => [{ type: 'Task', id: 'LIST' }, { type: 'GardenPlan', id: 'LIST' }],
+    }),
+
     // --- Auth Endpoints ---
     login: builder.mutation<{ access_token: string }, any>({
         query: (credentials) => ({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -87,6 +87,7 @@ export interface Task {
     id: number;
     garden_plan_id: number;
     planting_id?: number | null;
+    task_group_id?: number | null;
     name: string;
     description?: string | null;
     due_date?: string | null;


### PR DESCRIPTION
…planting.

When a new planting is created, the related tasks (e.g., sow, transplant, harvest) are now grouped together. This allows for proportional updates of their due dates and the ability to unlink them.

Key changes:
- Backend:
  - Added a `TaskGroup` model to link tasks.
  - Centralized task creation logic in the backend. When a planting is created, the backend now also creates and links the associated tasks.
  - Added new API endpoints to update and unlink task groups.
- Frontend:
  - Simplified the "Add to Plan" modal by removing complex client-side date calculation logic.
  - Updated the "Task Detail" modal to allow users to edit or unlink linked tasks.