### PR TITLE
This commit introduces a new feature to link tasks associated with a …

### DIFF
--- a/frontend/src/store/plantApi.ts
+++ b/frontend/src/store/plantApi.ts
@@ -286,6 +286,8 @@ export const {
   useAddTaskMutation,
   useUpdateTaskMutation,
   useDeleteTaskMutation,
+  useUpdateTaskGroupMutation,
+  useUnlinkTaskGroupMutation,
   useLoginMutation,
   useRegisterMutation,
   useImportMappedPlantsMutation,


### PR DESCRIPTION
…planting.

When a new planting is created, the related tasks (e.g., sow, transplant, harvest) are now grouped together. This allows for proportional updates of their due dates and the ability to unlink them.

Key changes:
- Backend:
  - Added a `TaskGroup` model to link tasks.
  - Centralized task creation logic in the backend. When a planting is created, the backend now also creates and links the associated tasks.
  - Added new API endpoints to update and unlink task groups.
- Frontend:
  - Simplified the "Add to Plan" modal by removing complex client-side date calculation logic.
  - Updated the "Task Detail" modal to allow users to edit or unlink linked tasks.

Fixes a runtime error where the `useUnlinkTaskGroupMutation` and `useUpdateTaskGroupMutation` hooks were not exported from `plantApi.ts`.