### PR TITLE
Feat: Add version number to side menu

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { DirtyContext } from './DirtyContext';
 import { PlanProvider, usePlan } from './context/PlanContext';
 import ChangePlanModal from './components/ChangePlanModal';
 import { useGetMostRecentGardenPlanQuery } from './store/plantApi';
+import packageJson from '../package.json';
 
 function SideMenu() {
   const { activePlan } = usePlan();
@@ -82,6 +83,9 @@ function SideMenu() {
           </ul>
         </nav>
         <div className="absolute bottom-0 left-0 w-full p-4">
+          <div className="text-center text-xs text-gray-400 mb-2">
+            Version: {packageJson.version}
+          </div>
           <button
             onClick={handleLogout}
             className="w-full text-left p-2 text-xl hover:bg-green-700 rounded transition duration-200"


### PR DESCRIPTION
This commit adds the application's version number to the bottom of the side menu. This helps users track whether the application has been updated properly.

The version number is read from `frontend/package.json` and displayed in the `SideMenu` component. The version number in `package.json` has been incremented to `0.1.0`.