### PR TITLE
Fix: Re-implement dark mode with black theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gardening App</title>
   </head>
-  <body>
+  <body class="bg-gray-100 dark:bg-black">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,22 +64,22 @@ function SideMenu() {
         <nav>
           <ul>
             <li className="mb-4">
-              <Link to="/" className="block p-2 text-xl hover:bg-green-700 rounded transition duration-200">
+      <Link to="/" className="block p-2 text-xl hover:bg-green-700 dark:hover:bg-green-600 rounded transition duration-200">
                 Home
               </Link>
             </li>
             <li className="mb-4">
-              <Link to="/tasks" className="block p-2 text-xl hover:bg-green-700 rounded transition duration-200">
+      <Link to="/tasks" className="block p-2 text-xl hover:bg-green-700 dark:hover:bg-green-600 rounded transition duration-200">
                 Tasks
               </Link>
             </li>
             <li className="mb-4">
-              <Link to="/plans" className="block p-2 text-xl hover:bg-green-700 rounded transition duration-200">
+      <Link to="/plans" className="block p-2 text-xl hover:bg-green-700 dark:hover:bg-green-600 rounded transition duration-200">
                 All Garden Plans
               </Link>
             </li>
             <li className="mb-4">
-              <Link to="/bulk-edit" className="block p-2 text-xl hover:bg-green-700 rounded transition duration-200">
+      <Link to="/bulk-edit" className="block p-2 text-xl hover:bg-green-700 dark:hover:bg-green-600 rounded transition duration-200">
                 Plant Library
               </Link>
             </li>
@@ -89,7 +89,7 @@ function SideMenu() {
           <div className="flex justify-center mb-2">
             <button
               onClick={toggleTheme}
-              className="px-4 py-2 text-sm rounded-md text-white bg-gray-700 hover:bg-gray-600"
+      className="px-4 py-2 text-sm rounded-md text-white bg-gray-700 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-500"
             >
               {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
             </button>
@@ -99,7 +99,7 @@ function SideMenu() {
           </div>
           <button
             onClick={handleLogout}
-            className="w-full text-left p-2 text-xl hover:bg-green-700 rounded transition duration-200"
+    className="w-full text-left p-2 text-xl hover:bg-green-700 dark:hover:bg-green-600 rounded transition duration-200"
           >
             Logout
           </button>
@@ -119,7 +119,7 @@ function AppLayout() {
 
   return (
     <DirtyContext.Provider value={{ isPageDirty, setIsPageDirty }}>
-      <div className={`fixed top-0 left-0 h-full bg-green-800 text-white w-64 transform transition-transform duration-300 ease-in-out ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} z-40 shadow-lg`}>
+      <div className={`fixed top-0 left-0 h-full bg-green-800 dark:bg-green-900 text-white w-64 transform transition-transform duration-300 ease-in-out ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} z-40 shadow-lg`}>
         <button
           onClick={toggleSidebar}
           className="absolute top-4 right-4 text-white text-3xl hover:text-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 rounded-full w-8 h-8 flex items-center justify-center"
@@ -136,7 +136,7 @@ function AppLayout() {
       <div className={`transition-all duration-300 ease-in-out`}>
         <button
           onClick={toggleSidebar}
-          className="fixed top-4 left-4 z-20 p-2 bg-green-700 text-white rounded-md shadow-lg"
+          className="fixed top-4 left-4 z-20 p-2 bg-green-700 dark:bg-green-800 text-white rounded-md shadow-lg"
           aria-label="Open menu"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>

--- a/frontend/src/HomePage.tsx
+++ b/frontend/src/HomePage.tsx
@@ -30,10 +30,10 @@ const CalendarDay: React.FC<{
       {({ open }) => (
         <>
           <Popover.Button
-            className={`w-full h-24 border-t border-r border-gray-200 p-2 flex flex-col justify-center items-center cursor-pointer transition-colors duration-150 ${open ? 'bg-green-100' : 'hover:bg-gray-50'}`}
+    className={`w-full h-24 border-t border-r border-gray-200 dark:border-gray-700 p-2 flex flex-col justify-center items-center cursor-pointer transition-colors duration-150 ${open ? 'bg-green-100 dark:bg-green-800/50' : 'hover:bg-gray-50 dark:hover:bg-gray-700'}`}
           >
-            <span className="text-xs text-gray-500">{format(day, 'EEE')}</span>
-            <span className={`text-2xl mt-1 ${dayIsToday ? 'font-bold text-blue-600' : 'text-gray-700'}`}>
+    <span className="text-xs text-gray-500 dark:text-gray-400">{format(day, 'EEE')}</span>
+    <span className={`text-2xl mt-1 ${dayIsToday ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-300'}`}>
               {format(day, 'd')}
             </span>
           </Popover.Button>
@@ -46,14 +46,14 @@ const CalendarDay: React.FC<{
             leaveFrom="opacity-100 translate-y-0"
             leaveTo="opacity-0 translate-y-1"
           >
-            <Popover.Panel className={`absolute z-10 w-48 p-2 mt-2 bg-white rounded-md shadow-lg ${popoverPanelClasses}`}>
-              <div className="flex flex-col space-y-1">
-                <button onClick={() => onActionSelect(PlantingMethod.DIRECT_SEEDING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 rounded">Direct Seed</button>
-                <button onClick={() => onActionSelect(PlantingMethod.SEED_STARTING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 rounded">Start Seeds</button>
-                <button onClick={() => onActionSelect(PlantingMethod.SEEDLING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 rounded">Plant Seedling</button>
-                <button onClick={() => onActionSelect('harvest', day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 rounded">Harvest</button>
-                <div className="border-t my-1"></div>
-                <button onClick={() => onActionSelect('task', day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 rounded">Add Task</button>
+    <Popover.Panel className={`absolute z-10 w-48 p-2 mt-2 bg-white dark:bg-gray-800 rounded-md shadow-lg ${popoverPanelClasses}`}>
+        <div className="flex flex-col space-y-1 text-gray-800 dark:text-gray-200">
+            <button onClick={() => onActionSelect(PlantingMethod.DIRECT_SEEDING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 rounded">Direct Seed</button>
+            <button onClick={() => onActionSelect(PlantingMethod.SEED_STARTING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 rounded">Start Seeds</button>
+            <button onClick={() => onActionSelect(PlantingMethod.SEEDLING, day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 rounded">Plant Seedling</button>
+            <button onClick={() => onActionSelect('harvest', day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 rounded">Harvest</button>
+            <div className="border-t my-1 dark:border-gray-600"></div>
+            <button onClick={() => onActionSelect('task', day)} className="w-full text-left p-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 rounded">Add Task</button>
               </div>
             </Popover.Panel>
           </Transition>
@@ -114,38 +114,38 @@ const CalendarWeek: React.FC<{
     };
 
     return (
-        <div className={`mb-8 p-4 rounded-lg transition-colors duration-300 ${isCurrent ? 'bg-green-100' : 'bg-white'}`}>
-            <h2 className="text-xl font-bold mb-2 text-gray-700">{format(week, 'MMMM yyyy')} - Week of {format(week, 'do')}</h2>
-            <div className="grid grid-cols-7 border-l border-b border-gray-200 rounded-lg">
+<div className={`mb-8 p-4 rounded-lg transition-colors duration-300 ${isCurrent ? 'bg-green-100 dark:bg-green-900/50' : 'bg-white dark:bg-gray-900'}`}>
+    <h2 className="text-xl font-bold mb-2 text-gray-700 dark:text-gray-200">{format(week, 'MMMM yyyy')} - Week of {format(week, 'do')}</h2>
+    <div className="grid grid-cols-7 border-l border-b border-gray-200 dark:border-gray-700 rounded-lg">
                 {weekDays.map((day, index) => (
                     <CalendarDay key={day.toString()} day={day} dayIndex={index} onActionSelect={onActionSelect} />
                 ))}
             </div>
-            <div className="p-4 bg-gray-50 border-l border-r border-b border-gray-200 rounded-b-lg -mt-2">
-                <h3 className="font-semibold text-gray-700 mb-2">This Week's Actions</h3>
+    <div className="p-4 bg-gray-50 dark:bg-gray-800 border-l border-r border-b border-gray-200 dark:border-gray-700 rounded-b-lg -mt-2">
+        <h3 className="font-semibold text-gray-700 dark:text-gray-200 mb-2">This Week's Actions</h3>
                 {weeklyTasks.length > 0 ? (
                     <ul className="space-y-1">
                         {weeklyTasks.map(item => {
                             const itemIsComplete = isComplete(item);
                             return (
-                                <li key={item.id} className="text-sm flex items-center justify-between p-1 rounded-md hover:bg-gray-200 transition-colors">
-                                    <div className={`flex items-center cursor-pointer flex-grow ${itemIsComplete ? 'line-through text-gray-500' : ''}`} onClick={() => onItemClick(item)}>
+<li key={item.id} className="text-sm flex items-center justify-between p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
+    <div className={`flex items-center cursor-pointer flex-grow ${itemIsComplete ? 'line-through text-gray-500 dark:text-gray-400' : 'text-gray-800 dark:text-gray-200'}`} onClick={() => onItemClick(item)}>
                                         <span className="font-medium w-24 flex-shrink-0">{format(item.date, 'EEE, MMM d')}:</span>
                                         <span className={`font-medium mr-2 ${getTaskColor(item.type)}`}>
                                             {getTaskIcon(item.type)} {item.type.charAt(0).toUpperCase() + item.type.slice(1)}:
                                         </span> 
-                                        <span className="text-gray-800">
+        <span className="text-gray-800 dark:text-gray-200">
                                           {item.name}
-                                          {item.type === 'task' && <span className="text-gray-500 text-xs ml-2">({(item.data as Task).status})</span>}
+          {item.type === 'task' && <span className="text-gray-500 dark:text-gray-400 text-xs ml-2">({(item.data as Task).status})</span>}
                                         </span>
                                     </div>
                                     <div className="flex items-center space-x-2 ml-4 flex-shrink-0">
                                         {itemIsComplete ? (
-                                            <button onClick={(e) => { e.stopPropagation(); onUndo(item); }} className="px-2 py-1 text-xs bg-yellow-500 text-white rounded hover:bg-yellow-600">Undo</button>
+            <button onClick={(e) => { e.stopPropagation(); onUndo(item); }} className="px-2 py-1 text-xs bg-yellow-500 text-white rounded hover:bg-yellow-600 dark:bg-yellow-600 dark:hover:bg-yellow-700">Undo</button>
                                         ) : (
-                                            <button onClick={(e) => { e.stopPropagation(); onComplete(item); }} className="px-2 py-1 text-xs bg-green-500 text-white rounded hover:bg-green-600">Done</button>
+            <button onClick={(e) => { e.stopPropagation(); onComplete(item); }} className="px-2 py-1 text-xs bg-green-500 text-white rounded hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700">Done</button>
                                         )}
-                                        <button onClick={(e) => { e.stopPropagation(); onDelete(item); }} className="px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600">Delete</button>
+        <button onClick={(e) => { e.stopPropagation(); onDelete(item); }} className="px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700">Delete</button>
                                     </div>
                                 </li>
                             );
@@ -410,9 +410,9 @@ const HomePage: React.FC = () => {
   if (!activePlan) {
     return (
         <div className="p-8 text-center">
-            <h1 className="text-2xl font-bold text-gray-700 mb-4">Welcome to Your Digital Garden</h1>
-            <p className="text-lg text-gray-600 mb-6">Before you start, create a new Plan to organize your garden.</p>
-            <Link to="/plans" className="px-6 py-3 bg-green-600 text-white font-bold rounded-lg hover:bg-green-700 transition-colors">
+    <h1 className="text-2xl font-bold text-gray-700 dark:text-gray-200 mb-4">Welcome to Your Digital Garden</h1>
+    <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">Before you start, create a new Plan to organize your garden.</p>
+    <Link to="/plans" className="px-6 py-3 bg-green-600 text-white font-bold rounded-lg hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600 transition-colors">
                 Create a Plan
             </Link>
         </div>

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -47,11 +47,11 @@ const LoginPage: React.FC = () => {
 
     return (
         <div className="container mx-auto p-4">
-            <div className="max-w-md mx-auto bg-white p-8 border border-gray-200 rounded-lg shadow-lg">
-                <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
+    <div className="max-w-md mx-auto bg-white dark:bg-gray-900 p-8 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
+        <h2 className="text-2xl font-bold mb-6 text-center text-gray-800 dark:text-gray-200">Login</h2>
                 <form onSubmit={handleSubmit}>
                     <div className="mb-4">
-                        <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="username">
+                <label className="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-2" htmlFor="username">
                             Username
                         </label>
                         <input
@@ -59,12 +59,12 @@ const LoginPage: React.FC = () => {
                             type="text"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
-                            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                    className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 leading-tight focus:outline-none focus:shadow-outline"
                             required
                         />
                     </div>
                     <div className="mb-6">
-                        <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="password">
+                <label className="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-2" htmlFor="password">
                             Password
                         </label>
                         <input
@@ -72,19 +72,19 @@ const LoginPage: React.FC = () => {
                             type="password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
+                    className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
                             required
                         />
                     </div>
                     <div className="flex items-center justify-between mb-4">
                         <button
                             type="submit"
-                            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
+                    className="bg-blue-500 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
                             disabled={isLoading}
                         >
                             {isLoading ? 'Signing In...' : 'Sign In'}
                         </button>
-                        <Link to="/register" className="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800">
+                <Link to="/register" className="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
                             Register
                         </Link>
                     </div>

--- a/frontend/src/RegistrationPage.tsx
+++ b/frontend/src/RegistrationPage.tsx
@@ -29,11 +29,11 @@ const RegistrationPage: React.FC = () => {
 
     return (
         <div className="container mx-auto p-4">
-            <div className="max-w-md mx-auto bg-white p-8 border border-gray-200 rounded-lg shadow-lg">
-                <h2 className="text-2xl font-bold mb-6 text-center">Register</h2>
+    <div className="max-w-md mx-auto bg-white dark:bg-gray-900 p-8 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
+        <h2 className="text-2xl font-bold mb-6 text-center text-gray-800 dark:text-gray-200">Register</h2>
                 <form onSubmit={handleSubmit}>
                     <div className="mb-4">
-                        <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="username">
+                <label className="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-2" htmlFor="username">
                             Username
                         </label>
                         <input
@@ -41,12 +41,12 @@ const RegistrationPage: React.FC = () => {
                             type="text"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
-                            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                    className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 leading-tight focus:outline-none focus:shadow-outline"
                             required
                         />
                     </div>
                     <div className="mb-6">
-                        <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="password">
+                <label className="block text-gray-700 dark:text-gray-300 text-sm font-bold mb-2" htmlFor="password">
                             Password
                         </label>
                         <input
@@ -54,7 +54,7 @@ const RegistrationPage: React.FC = () => {
                             type="password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
+        className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
                             required
                         />
                     </div>
@@ -62,7 +62,7 @@ const RegistrationPage: React.FC = () => {
                     <div className="flex items-center justify-between">
                         <button
                             type="submit"
-                            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
+        className="bg-blue-500 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
                             disabled={isLoading}
                         >
                             {isLoading ? 'Registering...' : 'Register'}

--- a/frontend/src/components/PlantSelectionModal.tsx
+++ b/frontend/src/components/PlantSelectionModal.tsx
@@ -30,8 +30,8 @@ const PlantSelectionModal: React.FC<PlantSelectionModalProps> = ({ isOpen, onClo
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4 text-center">
             <Transition.Child as={Fragment} enter="ease-out duration-300" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="ease-in duration-200" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-lg bg-white p-6 text-left align-middle shadow-xl transition-all">
-                <Dialog.Title as="h3" className="text-lg font-bold leading-6 text-gray-900">
+<Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-lg bg-white dark:bg-gray-900 p-6 text-left align-middle shadow-xl transition-all">
+    <Dialog.Title as="h3" className="text-lg font-bold leading-6 text-gray-900 dark:text-gray-200">
                   Select a Plant
                 </Dialog.Title>
                 <div className="mt-4">
@@ -40,15 +40,15 @@ const PlantSelectionModal: React.FC<PlantSelectionModalProps> = ({ isOpen, onClo
                     placeholder="Search plant library..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full p-2 border border-gray-300 rounded-md mb-4"
+            className="w-full p-2 border border-gray-300 dark:border-gray-700 rounded-md mb-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-200"
                   />
                   <div className="max-h-96 overflow-y-auto">
-                    {isLoading && <p>Loading plants...</p>}
+            {isLoading && <p className="text-gray-800 dark:text-gray-200">Loading plants...</p>}
                     {error && <p className="text-red-500">Error loading plants.</p>}
                     {filteredPlants?.map(plant => (
-                      <div key={plant.id} onClick={() => onSelectPlant(plant)} className="p-2 border-b hover:bg-gray-100 cursor-pointer">
-                        <p className="font-semibold">{plant.plant_name}</p>
-                        {plant.variety_name && <p className="text-sm text-gray-500">{plant.variety_name}</p>}
+                <div key={plant.id} onClick={() => onSelectPlant(plant)} className="p-2 border-b dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                    <p className="font-semibold text-gray-800 dark:text-gray-200">{plant.plant_name}</p>
+                    {plant.variety_name && <p className="text-sm text-gray-500 dark:text-gray-400">{plant.variety_name}</p>}
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
This commit re-implements the dark mode feature to be more robust and to use a black-based theme as requested by the user. The previous implementation was not applying styles correctly.

Key changes:
- The base background color for dark mode is now black, set on the `<body>` tag.
- All major components, including the side menu, login/registration pages, home page calendar, and modals, have been updated with more aggressive and consistent dark mode styles.
- Text colors have been adjusted for better contrast against the new dark backgrounds.
- The `ThemeContext` and toggle button functionality remain the same, but the visual result is now a complete and visible dark theme.