### PR TITLE
feat: Add gardening-themed font

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Prata&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-serif;
+  }
+}
 
 /* TanStack Table Resizer CSS */
 .resizer {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,7 +9,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        tahoma: ['Tahoma', 'sans-serif'], // <-- ADD THIS LINE
+        sans: ['"Open Sans"', 'sans-serif'],
+        serif: ['Prata', 'serif'],
       },
     },
   },


### PR DESCRIPTION
This commit changes the application's font to "Prata" for headings and "Open Sans" for body text to give it a more appropriate feel for a gardening app.

- Imports "Prata" and "Open Sans" from Google Fonts.
- Configures Tailwind CSS to use the new fonts.
- Applies the new fonts to headings and body text.

Note: Due to a file permission issue in the testing environment, these changes have not been fully tested.