### PR TITLE
feat: Implement automatic date calculation in Add Planting modal

### DIFF
--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -54,6 +54,7 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
   const lastChangedField = useRef<string | null>(null);
 
   const watchedDates = watch(['sowDate', 'transplantDate', 'harvestDate']);
+  const watchedPlantingMethod = watch('plantingMethod');
 
   useEffect(() => {
     if (!lastChangedField.current) return;
@@ -66,18 +67,18 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
         days_to_transplant_high: watch('daysToTransplant'),
     };
 
-    const newDates = calculateDates(currentValues, lastChangedField.current);
+    const newDates = calculateDates(currentValues, lastChangedField.current, watchedPlantingMethod);
 
-    if (newDates.planned_sow_date && newDates.planned_sow_date !== watchedDates[0]) {
-        setValue('sowDate', newDates.planned_sow_date);
+    if (newDates.planned_sow_date !== watchedDates[0]) {
+        setValue('sowDate', newDates.planned_sow_date || '');
     }
-    if (newDates.planned_transplant_date && newDates.planned_transplant_date !== watchedDates[1]) {
-        setValue('transplantDate', newDates.planned_transplant_date);
+    if (newDates.planned_transplant_date !== watchedDates[1]) {
+        setValue('transplantDate', newDates.planned_transplant_date || '');
     }
-    if (newDates.planned_harvest_start_date && newDates.planned_harvest_start_date !== watchedDates[2]) {
-        setValue('harvestDate', newDates.planned_harvest_start_date);
+    if (newDates.planned_harvest_start_date !== watchedDates[2]) {
+        setValue('harvestDate', newDates.planned_harvest_start_date || '');
     }
-  }, [watchedDates, setValue, watch]);
+  }, [watchedDates, setValue, watch, watchedPlantingMethod]);
   
   const parseDays = (timeValue: string | number | null | undefined): number | null => {
       if (timeValue === null || timeValue === undefined) return null;
@@ -190,7 +191,7 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
           {(watch("plantingMethod") === PlantingMethod.SEED_STARTING || watch("plantingMethod") === PlantingMethod.DIRECT_SEEDING) && (
              <div className="mb-4">
                 <label htmlFor="sow-date" className="block text-sm font-medium text-gray-700">Sow Date</label>
-                <input type="date" id="sow-date" {...register("sowDate")} onChange={() => lastChangedField.current = 'planned_sow_date'} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
+                <input type="date" id="sow-date" {...register("sowDate")} onChange={(e) => { setValue('sowDate', e.target.value); lastChangedField.current = 'planned_sow_date'; }} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
                 {errors.sowDate && <p className="text-red-500 text-xs mt-1">{errors.sowDate.message}</p>}
              </div>
           )}
@@ -198,14 +199,14 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
           {(watch("plantingMethod") === PlantingMethod.SEED_STARTING || watch("plantingMethod") === PlantingMethod.SEEDLING) && (
             <div className="mb-4">
                 <label htmlFor="transplant-date" className="block text-sm font-medium text-gray-700">Transplant Date</label>
-                <input type="date" id="transplant-date" {...register("transplantDate")} onChange={() => lastChangedField.current = 'planned_transplant_date'} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
+                <input type="date" id="transplant-date" {...register("transplantDate")} onChange={(e) => { setValue('transplantDate', e.target.value); lastChangedField.current = 'planned_transplant_date'; }} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
                 {errors.transplantDate && <p className="text-red-500 text-xs mt-1">{errors.transplantDate.message}</p>}
             </div>
           )}
 
           <div className="mb-4">
             <label htmlFor="harvest-date" className="block text-sm font-medium text-gray-700">Target Harvest Date</label>
-            <input type="date" id="harvest-date" {...register("harvestDate")} onChange={() => lastChangedField.current = 'planned_harvest_start_date'} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
+            <input type="date" id="harvest-date" {...register("harvestDate")} onChange={(e) => { setValue('harvestDate', e.target.value); lastChangedField.current = 'planned_harvest_start_date'; }} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
             {errors.harvestDate && <p className="text-red-500 text-xs mt-1">{errors.harvestDate.message}</p>}
             <p className="text-xs text-gray-500 mt-1">Enter any known dates. The related tasks will be created automatically.</p>
           </div>

--- a/frontend/src/utils/dateCalculations.ts
+++ b/frontend/src/utils/dateCalculations.ts
@@ -1,69 +1,76 @@
-import { Planting } from '../types';
+import { Planting, PlantingMethod } from '../types';
 import { add, sub } from 'date-fns';
 
-const parseDays = (days: string | number | null | undefined): number => {
+const parseDays = (days: string | number | null | undefined): number | null => {
+    if (days === null || days === undefined) return null;
     if (typeof days === 'number') {
         return days;
     }
     if (typeof days === 'string') {
+        if (days.trim() === '') return null;
         if (days.includes('-')) {
-            const [min, max] = days.split('-').map(d => parseInt(d.trim(), 10));
-            return Math.round((min + max) / 2);
+            const parts = days.split('-').map(d => parseInt(d.trim(), 10));
+            if (parts.length !== 2 || parts.some(isNaN)) return null;
+            return Math.round((parts[0] + parts[1]) / 2);
         }
-        return parseInt(days, 10);
+        const num = parseInt(days, 10);
+        return isNaN(num) ? null : num;
     }
-    return 0;
+    return null;
 };
 
-export const calculateDates = (planting: Partial<Planting>, changedField: string): Partial<Planting> => {
-    const newPlanting = { ...planting };
+export const calculateDates = (
+    planting: Partial<Planting>,
+    changedField: string,
+    plantingMethod?: PlantingMethod
+): { planned_sow_date?: string; planned_transplant_date?: string; planned_harvest_start_date?: string } => {
+    const timeToMaturity = parseDays(planting.time_to_maturity_override ?? planting.time_to_maturity);
+    const daysToTransplant = parseDays(planting.days_to_transplant_high);
 
-    const timeToMaturity = parseDays(newPlanting.time_to_maturity_override ?? newPlanting.time_to_maturity);
-    const daysToTransplant = parseDays(newPlanting.days_to_transplant_high);
+    if (timeToMaturity === null) return {};
 
-    switch (changedField) {
-        case 'planned_harvest_start_date':
-            if (newPlanting.planned_harvest_start_date) {
-                const harvestDate = new Date(newPlanting.planned_harvest_start_date);
-                if (!isNaN(harvestDate.getTime())) {
-                    const transplantDate = sub(harvestDate, { days: timeToMaturity });
-                    newPlanting.planned_transplant_date = transplantDate.toISOString().split('T')[0];
+    let sowDate: Date | undefined;
+    let transplantDate: Date | undefined;
+    let harvestDate: Date | undefined;
 
-                    const sowDate = sub(transplantDate, { days: daysToTransplant });
-                    newPlanting.planned_sow_date = sowDate.toISOString().split('T')[0];
-                }
-            }
-            break;
-
-        case 'planned_transplant_date':
-            if (newPlanting.planned_transplant_date) {
-                const transplantDate = new Date(newPlanting.planned_transplant_date);
-                 if (!isNaN(transplantDate.getTime())) {
-                    const harvestDate = add(transplantDate, { days: timeToMaturity });
-                    newPlanting.planned_harvest_start_date = harvestDate.toISOString().split('T')[0];
-
-                    const sowDate = sub(transplantDate, { days: daysToTransplant });
-                    newPlanting.planned_sow_date = sowDate.toISOString().split('T')[0];
-                }
-            }
-            break;
-
-        case 'planned_sow_date':
-            if (newPlanting.planned_sow_date) {
-                const sowDate = new Date(newPlanting.planned_sow_date);
-                if (!isNaN(sowDate.getTime())) {
-                    const transplantDate = add(sowDate, { days: daysToTransplant });
-                    newPlanting.planned_transplant_date = transplantDate.toISOString().split('T')[0];
-
-                    const harvestDate = add(transplantDate, { days: timeToMaturity });
-                    newPlanting.planned_harvest_start_date = harvestDate.toISOString().split('T')[0];
-                }
-            }
-            break;
-
-        default:
-            break;
+    if (changedField === 'planned_sow_date' && planting.planned_sow_date) {
+        sowDate = new Date(planting.planned_sow_date);
+    } else if (changedField === 'planned_transplant_date' && planting.planned_transplant_date) {
+        transplantDate = new Date(planting.planned_transplant_date);
+    } else if (changedField === 'planned_harvest_start_date' && planting.planned_harvest_start_date) {
+        harvestDate = new Date(planting.planned_harvest_start_date);
+    } else {
+        return {}; // No valid anchor
     }
 
-    return newPlanting;
+    if (sowDate && !isNaN(sowDate.getTime())) {
+        if (plantingMethod === PlantingMethod.DIRECT_SEEDING) {
+            harvestDate = add(sowDate, { days: timeToMaturity });
+        } else if (plantingMethod === PlantingMethod.SEED_STARTING && daysToTransplant !== null) {
+            transplantDate = add(sowDate, { days: daysToTransplant });
+            harvestDate = add(transplantDate, { days: timeToMaturity });
+        }
+    } else if (transplantDate && !isNaN(transplantDate.getTime())) {
+        if (plantingMethod === PlantingMethod.SEED_STARTING || plantingMethod === PlantingMethod.SEEDLING) {
+            harvestDate = add(transplantDate, { days: timeToMaturity });
+            if (plantingMethod === PlantingMethod.SEED_STARTING && daysToTransplant !== null) {
+                sowDate = sub(transplantDate, { days: daysToTransplant });
+            }
+        }
+    } else if (harvestDate && !isNaN(harvestDate.getTime())) {
+        if (plantingMethod === PlantingMethod.DIRECT_SEEDING) {
+            sowDate = sub(harvestDate, { days: timeToMaturity });
+        } else if (plantingMethod === PlantingMethod.SEED_STARTING || plantingMethod === PlantingMethod.SEEDLING) {
+            transplantDate = sub(harvestDate, { days: timeToMaturity });
+            if (plantingMethod === PlantingMethod.SEED_STARTING && daysToTransplant !== null) {
+                sowDate = sub(transplantDate, { days: daysToTransplant });
+            }
+        }
+    }
+
+    return {
+        planned_sow_date: sowDate?.toISOString().split('T')[0],
+        planned_transplant_date: transplantDate?.toISOString().split('T')[0],
+        planned_harvest_start_date: harvestDate?.toISOString().split('T')[0],
+    };
 };


### PR DESCRIPTION
Refactors the date calculation logic to automatically populate sow, transplant, and harvest dates based on user input and planting method.

- Updates `calculateDates` to be more robust, handling different planting methods and returning a complete date profile.
- Modifies `AddToPlanModal` to use the new calculation logic, ensuring that date fields are updated reactively.
- Fixes a bug with `react-hook-form`'s `onChange` handler to ensure form state is updated correctly, allowing the calculation to trigger as expected.