### PR TITLE
fix: Trigger date calculation on modal open

### DIFF
--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -113,12 +113,32 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
       
       if (initialDate) {
         const dateStr = format(initialDate, 'yyyy-MM-dd');
+        let anchorField: string | null = null;
+
         if (initialAction === 'harvest') {
             defaults.harvestDate = dateStr;
+            anchorField = 'planned_harvest_start_date';
         } else if (defaultPlantingMethod === PlantingMethod.SEEDLING) {
             defaults.transplantDate = dateStr;
+            anchorField = 'planned_transplant_date';
         } else {
             defaults.sowDate = dateStr;
+            anchorField = 'planned_sow_date';
+        }
+
+        if (anchorField) {
+            const currentValues = {
+                planned_sow_date: defaults.sowDate,
+                planned_transplant_date: defaults.transplantDate,
+                planned_harvest_start_date: defaults.harvestDate,
+                time_to_maturity: defaults.timeToMaturity,
+                days_to_transplant_high: defaults.daysToTransplant,
+            };
+            const newDates = calculateDates(currentValues, anchorField, defaultPlantingMethod);
+
+            if(newDates.planned_sow_date) defaults.sowDate = newDates.planned_sow_date;
+            if(newDates.planned_transplant_date) defaults.transplantDate = newDates.planned_transplant_date;
+            if(newDates.planned_harvest_start_date) defaults.harvestDate = newDates.planned_harvest_start_date;
         }
       }
 


### PR DESCRIPTION
This commit fixes a bug where the automatic date calculation was not being triggered when the 'Add Planting' modal was opened with a pre-selected date.

- Modifies the initialization `useEffect` in `AddToPlanModal.tsx` to immediately calculate all relevant dates when the modal is opened with an initial date and action.
- This ensures that the form is fully populated with the correct dates from the start, improving the user experience and fulfilling the intended workflow.