### PR TITLE
fix: Prevent date clearing on initial modal render

### DIFF
--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -52,6 +52,7 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
     resolver: zodResolver(plantingSchema),
   });
   const lastChangedField = useRef<string | null>(null);
+  const isInitialMount = useRef(true);
 
   const watchedDates = watch(['sowDate', 'transplantDate', 'harvestDate']);
   const watchedPlantingMethod = watch('plantingMethod');
@@ -82,9 +83,13 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
   }, [watchedDates, setValue, watch, watchedPlantingMethod]);
   
   useEffect(() => {
-    setValue('sowDate', '');
-    setValue('transplantDate', '');
-    setValue('harvestDate', '');
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      setValue('sowDate', '');
+      setValue('transplantDate', '');
+      setValue('harvestDate', '');
+    }
   }, [watchedPlantingMethod, setValue]);
 
   const parseDays = (timeValue: string | number | null | undefined): number | null => {


### PR DESCRIPTION
This commit fixes a bug where dates were being cleared immediately after being populated during the initial opening of the 'Add Planting' modal.

- A `useRef` flag (`isInitialMount`) is introduced to prevent the `useEffect` hook that clears dates from running on the initial component render.
- This resolves the conflict between the initialization effect and the clearing effect, ensuring that pre-selected and calculated dates are correctly displayed when the modal opens.