### PR TITLE
fix: Relax date validation to allow form submission

### DIFF
--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -25,7 +25,7 @@ const plantingSchema = z.object({
   daysToTransplant: z.string().regex(/^\d*$/, "Must be a number").optional(),
 }).refine(data => {
     if (data.sowDate && data.transplantDate) {
-        return new Date(data.transplantDate) > new Date(data.sowDate);
+        return new Date(data.transplantDate) >= new Date(data.sowDate);
     }
     return true;
 }, {
@@ -33,7 +33,7 @@ const plantingSchema = z.object({
     path: ["transplantDate"],
 }).refine(data => {
     if (data.transplantDate && data.harvestDate) {
-        return new Date(data.harvestDate) > new Date(data.transplantDate);
+        return new Date(data.harvestDate) >= new Date(data.transplantDate);
     }
     return true;
 }, {


### PR DESCRIPTION
This commit fixes a bug that prevented the 'Add Planting' form from being submitted. The issue was caused by an overly strict Zod validation rule that failed when calculated dates were the same (e.g., when 'Days to Transplant' or 'Time to Maturity' was 0).

- The date validation checks in the `plantingSchema` have been changed from a strict greater-than (>) to greater-than-or-equal-to (>=).
- This makes the validation more flexible and allows for same-day events, ensuring that the form can be submitted correctly after dates are auto-populated.