### PR TITLE
feat: Remove automatic task creation for new plantings

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -183,62 +183,6 @@ def create_planting(db: Session, garden_plan_id: int, planting_details: schemas.
     db.add(new_planting)
     db.flush()
 
-    # --- Task Creation Logic ---
-    task_group = models.TaskGroup()
-    db.add(task_group)
-    db.flush()
-
-    tasks_to_create = []
-    plant_name = library_plant.plant_name
-
-    if new_planting.planting_method == models.PlantingMethod.DIRECT_SEEDING:
-        if new_planting.planned_sow_date:
-            tasks_to_create.append(schemas.TaskCreate(
-                name=f"Sow seeds for {plant_name}",
-                due_date=new_planting.planned_sow_date,
-                garden_plan_id=garden_plan_id,
-                planting_id=new_planting.id,
-                task_group_id=task_group.id
-            ))
-    elif new_planting.planting_method == models.PlantingMethod.SEED_STARTING:
-        if new_planting.planned_sow_date:
-            tasks_to_create.append(schemas.TaskCreate(
-                name=f"Start seeds for {plant_name}",
-                due_date=new_planting.planned_sow_date,
-                garden_plan_id=garden_plan_id,
-                planting_id=new_planting.id,
-                task_group_id=task_group.id
-            ))
-        if new_planting.planned_transplant_date:
-            tasks_to_create.append(schemas.TaskCreate(
-                name=f"Transplant seedlings for {plant_name}",
-                due_date=new_planting.planned_transplant_date,
-                garden_plan_id=garden_plan_id,
-                planting_id=new_planting.id,
-                task_group_id=task_group.id
-            ))
-    elif new_planting.planting_method == models.PlantingMethod.SEEDLING:
-        if new_planting.planned_transplant_date:
-            tasks_to_create.append(schemas.TaskCreate(
-                name=f"Plant seedlings for {plant_name}",
-                due_date=new_planting.planned_transplant_date,
-                garden_plan_id=garden_plan_id,
-                planting_id=new_planting.id,
-                task_group_id=task_group.id
-            ))
-
-    if new_planting.planned_harvest_start_date:
-        tasks_to_create.append(schemas.TaskCreate(
-            name=f"Harvest {plant_name}",
-            due_date=new_planting.planned_harvest_start_date,
-            garden_plan_id=garden_plan_id,
-            planting_id=new_planting.id,
-            task_group_id=task_group.id
-        ))
-
-    for task_data in tasks_to_create:
-        db_task = models.Task(**task_data.model_dump())
-        db.add(db_task)
 
     db.commit()
     db.refresh(new_planting)

--- a/frontend/src/components/AddToPlanModal.tsx
+++ b/frontend/src/components/AddToPlanModal.tsx
@@ -246,7 +246,6 @@ const AddToPlanModal: React.FC<AddToPlanModalProps> = ({ isOpen, onClose, plant,
             <label htmlFor="harvest-date" className="block text-sm font-medium text-gray-700">Target Harvest Date</label>
             <input type="date" id="harvest-date" {...register("harvestDate")} onChange={(e) => { setValue('harvestDate', e.target.value); lastChangedField.current = 'planned_harvest_start_date'; }} className="mt-1 block w-full p-2 border border-gray-300 rounded-md"/>
             {errors.harvestDate && <p className="text-red-500 text-xs mt-1">{errors.harvestDate.message}</p>}
-            <p className="text-xs text-gray-500 mt-1">Enter any known dates. The related tasks will be created automatically.</p>
             {(!watchedTimeToMaturity || watchedTimeToMaturity === '0') &&
               <p className="text-xs text-orange-500 mt-1">
                 Enter Days to Maturity to enable automatic date calculation.


### PR DESCRIPTION
This change removes the functionality that automatically created tasks when a new planting was added to a garden plan.

The backend logic in `crud.create_planting` that generated these tasks has been removed.

The frontend has been updated to remove a message in the 'Add to Plan' modal that referred to the automatic task creation.

The ability to manage the status of a planting (e.g., 'Planned', 'Harvesting', 'Done') already exists in the application and is not affected by this change. This existing functionality fulfills the user's request to be able to assign a status to plantings.