### PR TITLE
fix: Add missing import in HomePage

### DIFF
--- a/frontend/src/HomePage.tsx
+++ b/frontend/src/HomePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, Fragment } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { usePlan } from './context/PlanContext';
-import { useGetGardenPlanByIdQuery, useUpdatePlantingMutation, useUpdateTaskMutation, useDeletePlantingMutation, useDeleteTaskMutation } from './store/plantApi';
+import { useGetGardenPlanByIdQuery, useGetMostRecentGardenPlanQuery, useUpdatePlantingMutation, useUpdateTaskMutation, useDeletePlantingMutation, useDeleteTaskMutation } from './store/plantApi';
 import { Plant, Planting, PlantingMethod, GardenPlan, Task, TaskStatus, PlantingStatus } from './types';
 import { format, addDays, startOfWeek, addWeeks, subWeeks, isSameDay, isToday, isSameWeek } from 'date-fns';
 import { Popover, Transition } from '@headlessui/react';


### PR DESCRIPTION
This commit fixes a `ReferenceError` in `HomePage.tsx` caused by a missing import for `useGetMostRecentGardenPlanQuery`. This function was added to the component to handle the loading of the most recent garden plan, but the import was missed.