### PR TITLE
Fix: Adjust long press sensitivity on plant library

### DIFF
--- a/frontend/src/BulkEditTable.tsx
+++ b/frontend/src/BulkEditTable.tsx
@@ -286,7 +286,7 @@ const BulkEditTable: React.FC = () => {
     if (!pointerStartPos.current) return;
     const dx = Math.abs(event.clientX - pointerStartPos.current.x);
     const dy = Math.abs(event.clientY - pointerStartPos.current.y);
-    if (dx > 10 || dy > 10) {
+    if (dx > 20 || dy > 20) {
       clearTimeout(longPressTimeout.current);
       pointerStartPos.current = null;
       window.removeEventListener('pointermove', handlePointerMove);

--- a/npm_output.log
+++ b/npm_output.log
@@ -4,16 +4,9 @@
 
 Port 8444 is in use, trying another one...
 Port 8445 is in use, trying another one...
+Port 8446 is in use, trying another one...
 
-  VITE v5.4.19  ready in 586 ms
+  VITE v5.4.19  ready in 681 ms
 
-  ➜  Local:   http://localhost:8446/
-  ➜  Network: http://192.168.0.2:8446/
-Error: The following dependencies are imported but could not be resolved:
-
-  react-colorful (imported by /app/frontend/src/components/ThemeCustomizeModal.tsx)
-
-Are they installed?
-    at file:///app/frontend/node_modules/vite/dist/node/chunks/dep-C6uTJdX2.js:50669:15
-    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
-    at async file:///app/frontend/node_modules/vite/dist/node/chunks/dep-C6uTJdX2.js:50174:26
+  ➜  Local:   http://localhost:8447/
+  ➜  Network: http://192.168.0.2:8447/


### PR DESCRIPTION
This commit addresses an issue where a "flick to scroll" gesture on the plant library page was being misinterpreted as a long press, incorrectly triggering selection mode.

The distance threshold for cancelling the long press has been increased from 10 to 20 pixels in `frontend/src/BulkEditTable.tsx`. This makes the gesture detection less sensitive and better distinguishes between a scroll/flick and an intentional long press.